### PR TITLE
Returning option for insert and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,13 @@ After creating a Handy PG component, the following methods will be available:
 | streamQuery | Same as `query`, but returns a stream ('data', 'error', 'end'). Multiple queries not possible (throws error). | `(stream) => {}` |
 | formattedQuery | Execute a formatted query using shorthands `SELECT %L::INT AS %I` | `(result) => {}` |
 | formattedStreamQuery | Same as formattedQuery but returns a stream ('data', 'error', 'end'). Multiple queries not possible (throws error). | `(stream) => {}` |
-| insert | Insert data `(table, data, options)` (object `options` is optional. It admits the boolean property `_returning` to retrieve inserted data) | `() => {}` |
-| update | Update data `(table, update, options)` (object `options` is optional. It admits where conditions and the `_returning` property as in `insert` )| `() => {}` |
+| insert | Insert data `(table, data, options)` (object `options` is optional. It accepts the boolean property `_returning` to retrieve inserted data) | `() => {}` |
+| update | Update data `(table, update, options)` (object `options` is optional. It accepts where conditions and the `_returning` property as in `insert` )| `() => {}` |
 | schema | Sets a schema and returns the query operations to use with that schema `(schema)`| `({ query, formattedQuery, insert, update }) => {}` |
 | explain | Execute an explain plan for an unformatted query |
 | formattedExplain | Execute an explain plan for a formatted query |
 | copyFrom | Copy table contents from read stream |
 | copyTo | Copy table contents to write stream |
-
 
 You can find some examples for query, formattedQuery, insert and update [here](https://github.com/guidesmiths/handy-postgres/blob/master/test/e2e/query.test.js)
 

--- a/README.md
+++ b/README.md
@@ -51,15 +51,16 @@ After creating a Handy PG component, the following methods will be available:
 | streamQuery | Same as `query`, but returns a stream ('data', 'error', 'end'). Multiple queries not possible (throws error). | `(stream) => {}` |
 | formattedQuery | Execute a formatted query using shorthands `SELECT %L::INT AS %I` | `(result) => {}` |
 | formattedStreamQuery | Same as formattedQuery but returns a stream ('data', 'error', 'end'). Multiple queries not possible (throws error). | `(stream) => {}` |
-| insert | Insert data `(table, data)` | `() => {}` |
-| update | Update data `(table, update, where)` (where is optional)| `() => {}` |
+| insert | Insert data `(table, data, options)` (object `options` is optional. It admits the boolean property `_returning` to retrieve inserted data) | `() => {}` |
+| update | Update data `(table, update, options)` (object `options` is optional. It admits where conditions and the `_returning` property as in `insert` )| `() => {}` |
 | schema | Sets a schema and returns the query operations to use with that schema `(schema)`| `({ query, formattedQuery, insert, update }) => {}` |
 | explain | Execute an explain plan for an unformatted query |
 | formattedExplain | Execute an explain plan for a formatted query |
 | copyFrom | Copy table contents from read stream |
 | copyTo | Copy table contents to write stream |
 
-You can find some examples for query, formattedQuery and insert [here](https://github.com/guidesmiths/handy-postgres/blob/master/test/e2e/query.test.js)
+
+You can find some examples for query, formattedQuery, insert and update [here](https://github.com/guidesmiths/handy-postgres/blob/master/test/e2e/query.test.js)
 
 ## Transactions
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ After creating a Handy PG component, the following methods will be available:
 | streamQuery | Same as `query`, but returns a stream ('data', 'error', 'end'). Multiple queries not possible (throws error). | `(stream) => {}` |
 | formattedQuery | Execute a formatted query using shorthands `SELECT %L::INT AS %I` | `(result) => {}` |
 | formattedStreamQuery | Same as formattedQuery but returns a stream ('data', 'error', 'end'). Multiple queries not possible (throws error). | `(stream) => {}` |
-| insert | Insert data `(table, data, options)` (object `options` is optional. It accepts the boolean property `_returning` to retrieve inserted data) | `() => {}` |
-| update | Update data `(table, update, options)` (object `options` is optional. It accepts where conditions and the `_returning` property as in `insert` )| `() => {}` |
+| insert | Insert data `(table, data, options)` (object `options` is optional. It accepts the boolean property `returning` to retrieve inserted data) | `() => {}` |
+| update | Update data `(table, update, where, options)` (objects `where` and `options` are optional. `where` accepts where conditions, `options` is analogous to `insert` usage)| `() => {}` |
 | schema | Sets a schema and returns the query operations to use with that schema `(schema)`| `({ query, formattedQuery, insert, update }) => {}` |
 | explain | Execute an explain plan for an unformatted query |
 | formattedExplain | Execute an explain plan for a formatted query |

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,6 +12,8 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
 
   const join = R.curryN(2, path.join);
 
+  const conditionalConcat = (val, concatVal, cond) => val.concat(cond && concatVal || '');
+
   const sqlFile = name => path.extname(name) === SQL_EXT;
 
   const readFile = R.partialRight(fs.readFileSync, [{ encoding: 'utf-8' }]);
@@ -57,7 +59,7 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
 
   const tableSql = (schema, table) => [schema, table].filter(Boolean).map(formatFn.ident).join('.');
 
-  const _prepareUpdate = (queries, schema, table, update, where) => {
+  const _prepareUpdate = (queries, schema, table, update, options) => {
     const sqlZip = (separator, obj) => {
       const ks = R.keys(obj);
       const vs = R.values(obj);
@@ -75,12 +77,12 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
 
     const tableClause = tableSql(schema, table);
     const updateClause = sqlZip(',', update);
-    const whereClause = R.when(Boolean, R.concat('WHERE '), sqlZip(' AND ', where));
-
-    return _prepare(sqlFormatter, queries, '_update', [tableClause, updateClause, whereClause]);
+    const whereClause = R.when(Boolean, R.concat('WHERE '), sqlZip(' AND ', R.dissoc('_returning', options)));
+    const queryName = conditionalConcat('_update', '_returning', R.equals(options._returning, true));
+    return _prepare(sqlFormatter, queries, queryName, [tableClause, updateClause, whereClause]);
   };
 
-  const _prepareInsert = (queries, schema, table, insertions) => {
+  const _prepareInsert = (queries, schema, table, insertions, options) => {
     const toInsert = [].concat(insertions);
     const keys = R.pipe(R.chain(R.keys), R.uniq)(toInsert);
     const cols = R.map(formatFn.ident, keys);
@@ -107,18 +109,20 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
     const tableClause = tableSql(schema, table);
     const valueClause = R.join('),\n(', vals);
     const params = [tableClause, columnClause, valueClause];
-    return _prepare(sqlFormatter, queries, '_insert', params);
+    const queryName = conditionalConcat('_insert', '_returning', R.equals(options._returning, true));
+    return _prepare(sqlFormatter, queries, queryName, params, options);
   };
 
-  const _insert = (pool, queries, schema) => (table, toInsert) => {
+  const _insert = (pool, queries, schema) => async (table, toInsert, options = {}) => {
     if (R.isEmpty(toInsert)) return Promise.resolve();
-    const prepared = _prepareInsert(queries, schema, table, toInsert);
+    const prepared = _prepareInsert(queries, schema, table, toInsert, options);
     debug(`Inserting ${prepared}`);
     return pool.query(...prepared);
   };
 
-  const _update = (pool, queries, schema) => (table, update, where) => {
-    const prepared = _prepareUpdate(queries, schema, table, update, where);
+  const _update = (pool, queries, schema) => (table, update, options = {}) => {
+    const prepared = _prepareUpdate(queries, schema, table, update, options);
+    debug(`Updating ${prepared}`);
     return pool.query(...prepared);
   };
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -113,7 +113,7 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
     return _prepare(sqlFormatter, queries, queryName, params, options);
   };
 
-  const _insert = (pool, queries, schema) => async (table, toInsert, options = {}) => {
+  const _insert = (pool, queries, schema) => (table, toInsert, options = {}) => {
     if (R.isEmpty(toInsert)) return Promise.resolve();
     const prepared = _prepareInsert(queries, schema, table, toInsert, options);
     debug(`Inserting ${prepared}`);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,8 +12,6 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
 
   const join = R.curryN(2, path.join);
 
-  const conditionalConcat = (val, concatVal, cond) => val.concat(cond && concatVal || '');
-
   const sqlFile = name => path.extname(name) === SQL_EXT;
 
   const readFile = R.partialRight(fs.readFileSync, [{ encoding: 'utf-8' }]);
@@ -59,7 +57,7 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
 
   const tableSql = (schema, table) => [schema, table].filter(Boolean).map(formatFn.ident).join('.');
 
-  const _prepareUpdate = (queries, schema, table, update, options) => {
+  const _prepareUpdate = (queries, schema, table, update, where, options) => {
     const sqlZip = (separator, obj) => {
       const ks = R.keys(obj);
       const vs = R.values(obj);
@@ -77,8 +75,8 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
 
     const tableClause = tableSql(schema, table);
     const updateClause = sqlZip(',', update);
-    const whereClause = R.when(Boolean, R.concat('WHERE '), sqlZip(' AND ', R.dissoc('_returning', options)));
-    const queryName = conditionalConcat('_update', '_returning', R.equals(options._returning, true));
+    const whereClause = R.when(Boolean, R.concat('WHERE '), sqlZip(' AND ', where));
+    const queryName = options.returning ? '_update_returning' : '_update';
     return _prepare(sqlFormatter, queries, queryName, [tableClause, updateClause, whereClause]);
   };
 
@@ -109,7 +107,7 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
     const tableClause = tableSql(schema, table);
     const valueClause = R.join('),\n(', vals);
     const params = [tableClause, columnClause, valueClause];
-    const queryName = conditionalConcat('_insert', '_returning', R.equals(options._returning, true));
+    const queryName = options.returning ? '_insert_returning' : '_insert';
     return _prepare(sqlFormatter, queries, queryName, params, options);
   };
 
@@ -120,8 +118,8 @@ module.exports = (locations = [], formatFn = require('pg-format'), isolationLeve
     return pool.query(...prepared);
   };
 
-  const _update = (pool, queries, schema) => (table, update, options = {}) => {
-    const prepared = _prepareUpdate(queries, schema, table, update, options);
+  const _update = (pool, queries, schema) => (table, update, where = {}, options = {}) => {
+    const prepared = _prepareUpdate(queries, schema, table, update, where, options);
     debug(`Updating ${prepared}`);
     return pool.query(...prepared);
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handy-postgres",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "A handy interface for simpler postgres",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handy-postgres",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A handy interface for simpler postgres",
   "main": "index.js",
   "scripts": {

--- a/sql/_insert_returning.sql
+++ b/sql/_insert_returning.sql
@@ -1,0 +1,1 @@
+INSERT INTO %s (%s) VALUES (%s) RETURNING *

--- a/sql/_update_returning.sql
+++ b/sql/_update_returning.sql
@@ -1,0 +1,1 @@
+UPDATE %s SET %s %s RETURNING *

--- a/test/e2e/query.test.js
+++ b/test/e2e/query.test.js
@@ -92,7 +92,7 @@ describe('Handy pg query test', () => {
 
   it('inserts rows using the shorthand with returning clause set to false', () => {
     const movie = { code: 'kurtz', title: 'Apocalypse Now', dateProd: new Date('1979-08-15'), kind: 'drama', len: 153 };
-    return insert('films', movie, { _returning: false })
+    return insert('films', movie, { returning: false })
     .then(({ rows }) => expect(rows).to.eql([]))
     .then(() => formattedQuery('select-all', ['films']))
     .then(({ rows }) => expect(R.head(rows)).to.eql(movie))
@@ -101,7 +101,7 @@ describe('Handy pg query test', () => {
 
   it('inserts rows using the shorthand with returning clause set to true', () => {
     const movie = { code: 'kurtz', title: 'Apocalypse Now', dateProd: new Date('1979-08-15'), kind: 'drama', len: 153 };
-    return insert('films', movie, { _returning: true })
+    return insert('films', movie, { returning: true })
     .then(({ rows }) => expect(R.head(rows)).to.eql(movie))
     .then(() => formattedQuery('select-all', ['films']))
     .then(({ rows }) => expect(R.head(rows)).to.eql(movie))
@@ -140,7 +140,7 @@ describe('Handy pg query test', () => {
     const movie1 = { code: 'kurtz', title: 'Apocalypse Now', dateProd: new Date('1979-08-15'), kind: 'drama', len: 153 };
     const movie2 = { code: 'pulpf', title: 'Pulp Fiction', kind: 'cult', dateProd: null, len: 178 };
     return insert('films', [movie1, movie2])
-    .then(() => update('films', { kind: 'super-cool' }, { code: 'pulpf', _returning: false }))
+    .then(() => update('films', { kind: 'super-cool' }, { code: 'pulpf'}, { returning: false }))
     .then(({ rows }) => expect(rows).to.eql([]))
     .then(() => formattedQuery('select-all', ['films']))
     .then(({ rows }) => {
@@ -154,7 +154,7 @@ describe('Handy pg query test', () => {
     const movie1 = { code: 'kurtz', title: 'Apocalypse Now', dateProd: new Date('1979-08-15'), kind: 'drama', len: 153 };
     const movie2 = { code: 'pulpf', title: 'Pulp Fiction', kind: 'cult', dateProd: null, len: 178 };
     return insert('films', [movie1, movie2])
-    .then(() => update('films', { kind: 'super-cool' }, { code: 'pulpf', _returning: true }))
+    .then(() => update('films', { kind: 'super-cool' }, { code: 'pulpf' }, { returning: true }))
     .then(({ rows }) => expect(rows[0]).to.eql(R.merge(movie2, { kind: 'super-cool' })))
     .then(() => formattedQuery('select-all', ['films']))
     .then(({ rows }) => {
@@ -168,7 +168,7 @@ describe('Handy pg query test', () => {
     const movie1 = { code: 'kurtz', title: 'Apocalypse Now', dateProd: new Date('1979-08-15'), kind: 'drama', len: 153 };
     const movie2 = { code: 'pulpf', title: 'Pulp Fiction', kind: 'cult', dateProd: null, len: 178 };
     return insert('films', [movie1, movie2])
-    .then(() => update('films', { kind: 'super-cool' }, { _returning: false }))
+    .then(() => update('films', { kind: 'super-cool' }, null, { returning: false }))
     .then(({ rows }) => expect(rows).to.eql([]))
     .then(() => formattedQuery('select-all', ['films']))
     .then(({ rows }) => {
@@ -182,7 +182,7 @@ describe('Handy pg query test', () => {
     const movie1 = { code: 'kurtz', title: 'Apocalypse Now', dateProd: new Date('1979-08-15'), kind: 'drama', len: 153 };
     const movie2 = { code: 'pulpf', title: 'Pulp Fiction', kind: 'cult', dateProd: null, len: 178 };
     return insert('films', [movie1, movie2])
-    .then(() => update('films', { kind: 'super-cool' }, { _returning: true }))
+    .then(() => update('films', { kind: 'super-cool' }, null, { returning: true }))
     .then(({ rows }) => {
       expect(rows[0]).to.eql(R.merge(movie1, { kind: 'super-cool' }));
       expect(rows[1]).to.eql(R.merge(movie2, { kind: 'super-cool' }));


### PR DESCRIPTION
### Main Changes

While working with this awesome library, we came across `insert` and `update` functions, which is really nice. However, we noticed these functions do not retrieve the newly inserted or updated rows, so the user needs to perform a select query after that.

We believe this functionality could be a nice feature to have. So in order to maintain backward compatibility, we propose to include an optional property to insert and update functions called `_returning`:

#### Insert function

Current insert function
```js
insert(table, data)
```
changes to
```js
insert(table, data, options)
```
where `options` is an optional object where only the boolean property called `_returning` is accepted

#### Update function

Current update function
```js
update(table, update, where)
```
changes to
```js
insert(table, update, options)
```
where `options` remains as an optional property (as `where` was) that accepts WHERE conditions, plus the previously mentioned `_returning` property

#### Reasons for this change

Our intention was to maintain backward compatibility, so we tried to do the fewer breaking changes as possible. As `update` function already has the optional property `where` to specify WHERE conditions, we wanted to keep it like it is now instead of adding a new function parameter for the returning option.

```js
const movie1 = { code: 'pulpf', title: 'Pulp Fiction', kind: 'cult', dateProd: null, len: 178 };
insert('films', [movie1]);
update('films', { kind: 'super-cool' }, { code: 'pulpf', _returning: true })
```
IMHO, having the `options` object with the properties `where` and `returning` would be a better approach, but this implies a bigger change to the API (which I can do if you agree)

```js
const movie1 = { code: 'pulpf', title: 'Pulp Fiction', kind: 'cult', dateProd: null, len: 178 };
insert('films', [movie1]);
update('films', { kind: 'super-cool' }, { 
  where: {
    code: 'pulpf',
  },
  returning: true
})
```
And we would no longer need to user the `_` in `returning` to make it different from the WHERE clauses.


For consistency reasons, we followed the same approach for `insert`: 

```js
const movie = { code: 'kurtz', title: 'Apocalypse Now', dateProd: new Date('1979-08-15'), kind: 'drama', len: 153 };
insert('films', movie, { _returning: true })
```
cc/ @inigomarquinez 

### Other Changes

- Explain new feature in README
- Add test for the new feature


### Changelog

- 6373d55 feat: add insert and update queries with returning by @neodmy
- 257f149 feat: add optional returing option for insert and update by @neodmy
- 7d50342 test: add tests for returning option in insert and update by @neodmy
- 8c5ee58 docs: document new option parameter for insert and update by @neodmy
- fd846b6 fix: polish changes by @neodmy
- 84352cf refactor: rename returning option and add as an extra param to update by @neodmy
- 9609ae0 test: amend tests after refactor by @neodmy
- 09a01f2 docs: amend README after refactor by @neodmy